### PR TITLE
Tense patch

### DIFF
--- a/builtin/fmt-merge-msg.c
+++ b/builtin/fmt-merge-msg.c
@@ -420,7 +420,7 @@ static void fmt_merge_msg_title(struct strbuf *out,
 	int i = 0;
 	char *sep = "";
 
-	strbuf_addstr(out, "Merge ");
+	strbuf_addstr(out, "Merged ");
 	for (i = 0; i < srcs.nr; i++) {
 		struct src_data *src_data = srcs.items[i].util;
 		const char *subsep = "";

--- a/sequencer.c
+++ b/sequencer.c
@@ -1812,7 +1812,7 @@ static int do_pick_commit(struct repository *r,
 		base_label = msg.label;
 		next = parent;
 		next_label = msg.parent_label;
-		strbuf_addstr(&msgbuf, "Revert \"");
+		strbuf_addstr(&msgbuf, "Reverted \"");
 		strbuf_addstr(&msgbuf, msg.subject);
 		strbuf_addstr(&msgbuf, "\"\n\nThis reverts commit ");
 		strbuf_addstr(&msgbuf, oid_to_hex(&commit->object.oid));


### PR DESCRIPTION
Converted built-in git merge and revert messages from imperative to past tense, simultaneously harmonizing git with my preferred commit message style, and resolving hundreds of useless online debates.